### PR TITLE
docs(readme): 在顶部补充迁移声明

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
-> **Migration notice (2026-08-26)**  
-> This repository ([`datagallery-lab/datafoundry`](https://github.com/datagallery-lab/datafoundry)) is now a fork.  
-> **Canonical upstream:** [`datagallery-ai/datafoundry`](https://github.com/datagallery-ai/datafoundry)  
-> Please clone, file issues, and open PRs on the source repo: <https://github.com/datagallery-ai/datafoundry> · Docs: <https://datagallery-ai.github.io/datafoundry/>
+## ⚠️ Repository Migration Notice
+
+> **This repository ([`datagallery-lab/datafoundry`](https://github.com/datagallery-lab/datafoundry)) is now a fork.**
+>
+> **The active and sole upstream is [`datagallery-ai/datafoundry`](https://github.com/datagallery-ai/datafoundry).**
+>
+> **Open issues and PRs, and clone the project, from the [source repository](https://github.com/datagallery-ai/datafoundry).** Documentation: <https://datagallery-ai.github.io/datafoundry/>
+
+---
 
 <h1 align="center">DataFoundry</h1>
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+> **Migration notice (2026-08-26)**  
+> This repository ([`datagallery-lab/datafoundry`](https://github.com/datagallery-lab/datafoundry)) is now a fork.  
+> **Canonical upstream:** [`datagallery-ai/datafoundry`](https://github.com/datagallery-ai/datafoundry)  
+> Please clone, file issues, and open PRs on the source repo: <https://github.com/datagallery-ai/datafoundry> · Docs: <https://datagallery-ai.github.io/datafoundry/>
+
 <h1 align="center">DataFoundry</h1>
 
 <p align="center">

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,7 +1,12 @@
-> **迁移声明（2026-08-26）**  
-> 本仓库 [`datagallery-lab/datafoundry`](https://github.com/datagallery-lab/datafoundry) 已变为 fork。  
-> **现役上游：** [`datagallery-ai/datafoundry`](https://github.com/datagallery-ai/datafoundry)  
-> Issue、PR、克隆与文档请改到源仓：<https://github.com/datagallery-ai/datafoundry> · 文档站 <https://datagallery-ai.github.io/datafoundry/>
+## ⚠️ 仓库迁移声明
+
+> **本仓库 [`datagallery-lab/datafoundry`](https://github.com/datagallery-lab/datafoundry) 已变为 fork。**
+>
+> **现役且唯一的上游是 [`datagallery-ai/datafoundry`](https://github.com/datagallery-ai/datafoundry)。**
+>
+> **Issue、PR 和 Clone 均请前往 [源仓](https://github.com/datagallery-ai/datafoundry)。** 文档站：<https://datagallery-ai.github.io/datafoundry/>
+
+---
 
 <h1 align="center">DataFoundry</h1>
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,3 +1,8 @@
+> **迁移声明（2026-08-26）**  
+> 本仓库 [`datagallery-lab/datafoundry`](https://github.com/datagallery-lab/datafoundry) 已变为 fork。  
+> **现役上游：** [`datagallery-ai/datafoundry`](https://github.com/datagallery-ai/datafoundry)  
+> Issue、PR、克隆与文档请改到源仓：<https://github.com/datagallery-ai/datafoundry> · 文档站 <https://datagallery-ai.github.io/datafoundry/>
+
 <h1 align="center">DataFoundry</h1>
 
 <p align="center">


### PR DESCRIPTION
## Summary
- 仅在 `README.md` / `README_zh.md` 顶部增加迁移声明。
- 说明本仓已是 fork，现役上游为 `datagallery-ai/datafoundry`。

## Test plan
- [ ] GitHub 仓库首页打开 README，顶部可见迁移声明
- [ ] 中英文 README 均有对应说明